### PR TITLE
Fix evaluation on current nixpkgs: nodePackages.asar → asar

### DIFF
--- a/pkgs/claude-desktop.nix
+++ b/pkgs/claude-desktop.nix
@@ -5,7 +5,7 @@
   electron,
   p7zip,
   libicns,
-  nodePackages,
+  asar,
   imagemagick,
   makeDesktopItem,
   makeWrapper,
@@ -31,7 +31,7 @@ stdenvNoCC.mkDerivation rec {
 
   nativeBuildInputs = [
     p7zip
-    nodePackages.asar
+    asar
     makeWrapper
     imagemagick
     libicns


### PR DESCRIPTION
nixpkgs removed the `nodePackages` set in March 2026, so this flake fails to evaluate when its `nixpkgs` input follows current unstable (`error: nodePackages has been removed...`). `asar` is a top-level package now — this swaps the reference in `pkgs/claude-desktop.nix`.

Verified: `nix build .#claude-desktop --dry-run --override-input nixpkgs github:nixos/nixpkgs/nixos-unstable` evaluates cleanly.

Context: claudeos currently pins an old nixpkgs for this input as a workaround (`nixpkgs-claude-desktop` in its flake.nix) — once this merges, that pin can be dropped and the input can go back to `follows = "nixpkgs"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)