### PR TITLE
fix: resolve desktop file by glob, update to 1.24012.9

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ The package works by:
 2. Extracting it (via `dpkg-deb --fsys-tarfile | tar --no-same-permissions` — plain `dpkg-deb -x` fails in the sandbox on the SUID `chrome-sandbox`)
 3. Patching ELF rpaths with `autoPatchelfHook` (main binary, crashpad handler, bundled `virtiofsd`, `@ant/claude-native` and `node-pty` Node modules)
 4. Removing `chrome-sandbox` (can't be SUID in the store; the userns sandbox is used instead)
-5. Shipping upstream's desktop file (`claude-desktop.desktop`, window class `claude-desktop`) and hicolor icons, with `Exec` pointed at the wrapper
+5. Shipping upstream's desktop file (currently `com.anthropic.Claude.desktop`, window class `com.anthropic.Claude`) and hicolor icons, with every `Exec` pointed at the wrapper. The name is **not** hardcoded — upstream renamed it once already (`claude-desktop.desktop` → `com.anthropic.Claude.desktop` in 1.20186.1, which broke the build), so the install phase globs `share/applications/*.desktop`, requires exactly one match, and derives `CHROME_DESKTOP` from it
 6. Wrapping with Wayland-friendly Chromium flags (`--ozone-platform-hint=auto`, GlobalShortcutsPortal, Wayland IME; `CLAUDE_USE_X11=1` escape hatch)
 
 Key files:

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ inputs.claude-desktop.packages.${system}.claude-desktop-with-fhs
 
 Both `x86_64-linux` and `aarch64-linux` are supported — upstream publishes amd64 and arm64 debs.
 
-> **Upgrading from the pre-native-build flake:** the desktop file is now upstream's `claude-desktop.desktop` (window class `claude-desktop`) instead of this flake's old `Claude.desktop`. If you had Claude pinned to your dock, re-pin it once after upgrading.
+> **Upgrading:** the desktop file is upstream's, and upstream renamed it in 1.20186.1 — it is now `com.anthropic.Claude.desktop` (window class `com.anthropic.Claude`), previously `claude-desktop.desktop`, and before the native-build switch this flake's own `Claude.desktop`. If you had Claude pinned to your dock, re-pin it once after upgrading.
 
 ## How it works
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -13,15 +13,16 @@ These fail the build or the `update-claude-desktop` workflow if they regress:
 | Deb matches the apt index | `fetchurl` verifies the pinned SHA256 (repinned by CI from the signed apt `Packages` index) |
 | Every ELF's dependencies resolve | `autoPatchelfHook` fails the build on any unsatisfied `DT_NEEDED` (covers the main binary, crashpad, bundled virtiofsd, native Node modules) |
 | Package builds end to end | `nix build .#claude-desktop` (run by CI on every version bump) |
-| `claude://` is registered | upstream desktop file ships `MimeType=x-scheme-handler/claude`; `update-desktop-database` maps it to `claude-desktop.desktop` |
+| `claude://` is registered | upstream desktop file ships `MimeType=x-scheme-handler/claude`; `update-desktop-database` maps it to `com.anthropic.Claude.desktop` |
 | Desktop file is valid | `desktop-file-validate` (run manually below) |
+| Desktop file is found at all | the install phase globs `share/applications/*.desktop` and fails unless exactly one matches, so an upstream rename can't silently ship an unpatched `Exec=` |
 
 Quick local re-run:
 
 ```bash
 NIXPKGS_ALLOW_UNFREE=1 nix build .#claude-desktop --impure -L
 OUT=$(readlink -f result)
-nix shell nixpkgs#desktop-file-utils -c desktop-file-validate "$OUT"/share/applications/claude-desktop.desktop
+nix shell nixpkgs#desktop-file-utils -c desktop-file-validate "$OUT"/share/applications/*.desktop
 ```
 
 ## Manual matrix (run on the testbed)

--- a/pkgs/claude-desktop.nix
+++ b/pkgs/claude-desktop.nix
@@ -44,7 +44,7 @@
 }:
 let
   pname = "claude-desktop";
-  version = "1.18286.0";
+  version = "1.24012.9";
 
   # Official Anthropic apt repository for the native Linux build.
   # Version discovery: fetch
@@ -58,11 +58,11 @@ let
   srcs = {
     x86_64-linux = fetchurl {
       url = "${aptRepo}/pool/main/c/claude-desktop/claude-desktop_${version}_amd64.deb";
-      hash = "sha256-jzFK0agKq1JxGo6qvAaq5I+zQfCt6koNcmTbXKudBTY=";
+      hash = "sha256-MC5tII3YyOnlIGfaoo7zsRcaFhNYb9DhC+3GQiJbbuE=";
     };
     aarch64-linux = fetchurl {
       url = "${aptRepo}/pool/main/c/claude-desktop/claude-desktop_${version}_arm64.deb";
-      hash = "sha256-SCC5iankMzlWtsvq7icy3StJkE+6VAtHKWPIADyAhsc=";
+      hash = "sha256-Gpvhd7BjNluS5SL+3RnIfa9uvJKp9xEhvf9ynifeQIw=";
     };
   };
 in
@@ -158,10 +158,27 @@ stdenv.mkDerivation {
     # profile is required — see README "Sandboxing on non-NixOS".
     rm $out/lib/${pname}/chrome-sandbox
 
-    # Upstream desktop file has Exec=claude-desktop (PATH-relative, including
-    # the NewChat/NewCode actions); point every Exec at the wrapper so it
-    # also works when the package isn't in PATH (e.g. `nix run`).
-    substituteInPlace $out/share/applications/claude-desktop.desktop \
+    # Resolve the desktop file rather than pinning its name: upstream renamed
+    # it claude-desktop.desktop -> com.anthropic.Claude.desktop in 1.20186.1,
+    # which hard-broke the build. Insist on exactly one match so an unexpected
+    # layout still fails loudly instead of silently shipping an unpatched (or
+    # missing) entry. nullglob so a zero-match glob is an empty array rather
+    # than the literal pattern.
+    shopt -s nullglob
+    desktopFiles=($out/share/applications/*.desktop)
+    shopt -u nullglob
+    if [ ''${#desktopFiles[@]} -ne 1 ]; then
+      echo "claude-desktop: expected exactly one .desktop file in" \
+           "share/applications, found ''${#desktopFiles[@]}: ''${desktopFiles[*]}" >&2
+      exit 1
+    fi
+    desktopFile="''${desktopFiles[0]}"
+    desktopName="$(basename "$desktopFile")"
+
+    # Every Exec= is PATH-relative (the main entry plus the NewChat/NewCode
+    # actions); point them all at the wrapper so launching also works when the
+    # package isn't in PATH (e.g. `nix run`).
+    substituteInPlace "$desktopFile" \
       --replace-fail "Exec=claude-desktop" "Exec=$out/bin/claude-desktop"
 
     # Default to native Wayland via Ozone. --ozone-platform-hint=auto
@@ -184,7 +201,7 @@ stdenv.mkDerivation {
       --add-flags "--wayland-text-input-version=3" \
       --add-flags "\''${CLAUDE_USE_X11:+--ozone-platform=x11}" \
       --set-default GTK_USE_PORTAL "1" \
-      --set CHROME_DESKTOP "claude-desktop.desktop" \
+      --set CHROME_DESKTOP "$desktopName" \
       --prefix XDG_DATA_DIRS : "$out/share"
 
     runHook postInstall


### PR DESCRIPTION
## Summary

Fixes the two-week CI outage and catches the flake up from **1.18286.0 → 1.24012.9** (five releases behind).

Upstream renamed the desktop file in 1.20186.1:

| | before | after |
|---|---|---|
| desktop file | `claude-desktop.desktop` | `com.anthropic.Claude.desktop` |
| `StartupWMClass` | `claude-desktop` | `com.anthropic.Claude` |

The install phase hardcoded the old name in `substituteInPlace --replace-fail`, so every scheduled update run since 2026-07-13 died at the build gate:

```
substitute(): ERROR: file '.../share/applications/claude-desktop.desktop' does not exist
error: Cannot build '...-claude-desktop-1.22209.3.drv'
```

The gate behaved correctly — it stopped a hash-only bump from shipping a package whose desktop entry pointed at nothing — but nothing repaired it, so the pin went stale.

## Changes

- **Resolve the desktop file by glob instead of pinning its name**, and derive `CHROME_DESKTOP` from the same lookup so the wrapper env and the installed file can't drift apart. Requires *exactly one* match, so an unexpected layout still fails loudly rather than silently shipping an unpatched `Exec=`. `nullglob` keeps a zero-match glob from expanding to the literal pattern and sneaking past the count check.
- **Bump to 1.24012.9**, both arch hashes repinned from the signed apt `Packages` index.
- Docs updated for the new name and window class (`CLAUDE.md`, `README.md`, `TESTING.md`), plus a TESTING row covering the new guard.

Nothing else in the deb moved — binary paths, crashpad handler, bundled `virtiofsd` and hicolor icon names are unchanged. `autoPatchelfHook` resolves the two new binaries in this release (`chrome-native-host`, `cowork-linux-helper`) with no new inputs.

## Verification

Built locally on `x86_64-linux`:

| Check | Result |
|---|---|
| `nix build .#claude-desktop` | passes, `0 dependencies could not be satisfied` |
| All three `Exec=` lines patched | main entry + NewChat + NewCode → wrapper path |
| `CHROME_DESKTOP` | `com.anthropic.Claude.desktop`, matches shipped file |
| `desktop-file-validate` | passes (one cosmetic upstream hint re: dual Categories) |
| `chrome-sandbox` removed | confirmed |
| Count guard on 0 / 1 / 2 matches | fails / passes / fails, unit-tested separately |

## Notes for review

- The **arm64 hash is not exercised by CI** — it comes from the apt index and is only verified when someone actually builds on aarch64. Pre-existing property of the update workflow, not introduced here.
- **Dock icons will need re-pinning** once after upgrading, since `StartupWMClass` changed. Called out in the README.
- The update workflow YAML needed no changes; next Monday's scheduled run should find the flake already current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)