### PR TITLE
docs: document the build workflow in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@ Key files:
 - `/pkgs/claude-desktop.nix`: The package definition
 - `/flake.nix`: Flake outputs, including the FHS wrapper for MCP support
 - `/.github/workflows/update-claude-desktop.yml`: Weekly auto-update from the apt `Packages` index
+- `/.github/workflows/build.yml`: Build verification for hand-authored PRs — checks both arch hashes against the apt index, runs `nix build`, and asserts the packaging invariants (exactly one `.desktop` file, no unpatched `Exec=`, `CHROME_DESKTOP` matching it, no `chrome-sandbox`). `Build gate` is the job to mark required in branch protection; `build` and `hashes` skip on docs-only changes and would deadlock a required check
 
 ### Updating for a new version
 


### PR DESCRIPTION
## Summary

`CLAUDE.md`'s "Key files" listed `update-claude-desktop.yml` but not `build.yml`, added in #112/#113. Adds it, and records **which job to mark required** in branch protection — picking `build` or `hashes` instead would deadlock docs-only PRs on a job that legitimately skips.

## Second purpose: end-to-end test of the skip path

This PR changes **only `CLAUDE.md`**, so it should exercise the path that #113 exists to protect:

| Job | Expected |
|---|---|
| `Detect relevant changes` | `relevant=false` |
| `Pinned hashes match apt index` | **skipped** |
| `nix build (x86_64-linux)` | **skipped** |
| `Build gate` | **✓ pass** |

That last row is the claim worth proving. I'd verified it in two halves — the detector returns `relevant=false` on a real docs diff, and the gate passes on `skipped/skipped` — but never as a single run. If `Build gate` reports green here with the build skipped, the chain is confirmed and branch protection is safe to enable.

If it goes red or hangs, better to find out now, with protection off, than to have every future docs PR wedged behind it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)